### PR TITLE
Allow private subrepos during jenkins builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,9 +16,10 @@ pipeline {
 		    module load cmake
 
 		    echo 'Building LibChemist'
-		    mkdir -p root		    
+		    mkdir -p root	
+		    export DESTDIR=${PWD}/root
 		    cd LibChemist
-		    cmake -DCMAKE_INSTALL_PREFIX=../root -H. -Bbuild
+		    cmake -H. -Bbuild
 		    cd build
 		    make && make install
 		    cd ../../


### PR DESCRIPTION
Working recipe for cloning private subrepo build dependencies. Dependencies will be installed to a folder called root located in the top-level workspace directory.


 The credentialsId string is linked to my personal github account. It can be used to authenticate  any of the NWX repos I have permissions for.

