### PR TITLE
These three files use a long int instead of unsigned long form basiss…

### DIFF
--- a/Integrals/FourCTensorBuilder.cpp
+++ b/Integrals/FourCTensorBuilder.cpp
@@ -12,8 +12,8 @@ std::vector<typename IntegralTensorBuilder<4>::TensorType> kernel(const LibChemi
     libint_type libints(0,molecule,basissets[0],basissets[1],basissets[2],basissets[3]);
     Integrals::FourCenterIntegral *Ints = &libints;
     IntegralTensorBuilder<4>::TensorType init_tensor(std::array<long int,4>
-                                                     {basissets[0].size(),basissets[1].size(),
-                                                      basissets[2].size(),basissets[3].size()});
+                                                     {static_cast<long>(basissets[0].size()),static_cast<long>(basissets[1].size()),
+                                                      static_cast<long>(basissets[2].size()),static_cast<long>(basissets[3].size())});
     init_tensor.setZero();
     std::vector<IntegralTensorBuilder<4>::TensorType> rv(Ints->n_components(),init_tensor);
 

--- a/Integrals/ThreeCTensorBuilder.cpp
+++ b/Integrals/ThreeCTensorBuilder.cpp
@@ -12,7 +12,8 @@ std::vector<typename IntegralTensorBuilder<3>::TensorType> kernel(const LibChemi
     libint_type libints(0,molecule,basissets[0],basissets[1],basissets[2]);
     Integrals::ThreeCenterIntegral *Ints = &libints;
     IntegralTensorBuilder<3>::TensorType init_tensor(std::array<long int,3>
-                                                     {basissets[0].size(),basissets[1].size(),basissets[2].size()});
+                                                     {static_cast<long>(basissets[0].size()),static_cast<long>(basissets[1].size()),
+                                                      static_cast<long>(basissets[2].size())});
     init_tensor.setZero();
     std::vector<IntegralTensorBuilder<3>::TensorType> rv(Ints->n_components(),init_tensor);
 

--- a/Integrals/TwoCTensorBuilder.cpp
+++ b/Integrals/TwoCTensorBuilder.cpp
@@ -12,7 +12,7 @@ std::vector<typename IntegralTensorBuilder<2>::TensorType> kernel(const LibChemi
     libint_type libints(0,molecule,basissets[0],basissets[1]);
     Integrals::TwoCenterIntegral *Ints = &libints;
     IntegralTensorBuilder<2>::TensorType init_tensor(std::array<long int,2>
-                                                    {basissets[0].size(),basissets[1].size()});
+                                                    {static_cast<long>(basissets[0].size()),static_cast<long>(basissets[1].size())});
     init_tensor.setZero();
     std::vector<IntegralTensorBuilder<2>::TensorType> rv(Ints->n_components(),init_tensor);
 


### PR DESCRIPTION
…et.size(). It fails for clang. Adding a static_cast to long for those three files.

## Status

- [x ] Ready to go

## Brief Description
Adding static_cast to long for basisset.size() that is unsigned long in LibChemist. Clang fails to compile this. 

## Detailed Description

Three files, TwoCTensorBuilder.cpp, ThreeCTensorBuilder.cpp, FourCTensorBuilder.cpp, use basisset.size() that returns a unsigned long, and implicitly cast it to a "long int". Clang does not like this. I added static_cast<long>() around those variables. 

Ctest passes all the tests.

Fixes issue https://github.com/NWChemEx-Project/Integrals/issues/10

## TODOs and/or Questions