### PR TITLE
Implement Integral Tensors to be filled by a lambda

### DIFF
--- a/Integrals/LibintIntegral.cpp
+++ b/Integrals/LibintIntegral.cpp
@@ -273,9 +273,16 @@ Integral<op, NBases, element_type>::run(
 }
 
 template<libint2::Operator op, size_type NBases, typename element_type>
-Integral<op, NBases, element_type>::Integral() :
-pimpl_(std::make_unique<DirectIntegrals<op, NBases, element_type>>()) {}
-//pimpl_(std::make_unique<CoreIntegrals<op, NBases, element_type>>()) {}
+Integral<op, NBases, element_type>::Integral(implementation_type impl) {
+    switch (impl) {
+        case implementation_type::direct:
+            pimpl_ = std::make_unique<DirectIntegrals<op, NBases, element_type>>();
+            break;
+        case implementation_type::core:
+            pimpl_ = std::make_unique<CoreIntegrals<op, NBases, element_type>>();
+            break;
+    }
+}
 
 template<libint2::Operator op, size_type NBases, typename element_type>
 Integral<op, NBases, element_type>::~Integral() noexcept = default;

--- a/Integrals/LibintIntegral.hpp
+++ b/Integrals/LibintIntegral.hpp
@@ -24,6 +24,9 @@ template<libint2::Operator op, std::size_t NBases,
         typename element_type = double>
 class IntegralPIMPL;
 
+///Enum containing the possible implementations
+enum class implementation_type {direct, core};
+
 /**
  * @brief The class that actually serves as the module for computing integrals
  *        for NWChemEx.
@@ -56,9 +59,10 @@ struct Integral : LibChemist::AOIntegral<NBases, element_type> {
     ///@}
 
     ///Initializes the buffers libint will need
-    Integral();
+    Integral(implementation_type impl = implementation_type::direct);
     ///Frees the buffers libint uses
     ~Integral() noexcept;
+
 
 
     /**


### PR DESCRIPTION
## Status

- [x] Ready to go

## Brief Description
Currently we store all integrals in memory. This PR will allow construction of Tensors to be filled in by lambda as needed.
## Detailed Description

## TODOs and/or Questions
- Integrals with multiple components (like dipoles) are not currently handled very well, there are some duplicate computations. Something to consider later on.