### PR TITLE
Update tamm:fill_tensor to new TAMM API

### DIFF
--- a/integrals/libint_integral.cpp
+++ b/integrals/libint_integral.cpp
@@ -47,7 +47,7 @@ private:
 
         tensor_type A{tAO};
         tamm::Tensor<element_type>::allocate(&ec, A);
-        tamm::fill_tensor<element_type>(ec, A, lambda);
+        tamm::fill_tensor<element_type>(A, lambda);
         return A;
     }
 };


### PR DESCRIPTION
New TAMM API for fill_tensor breaks Integrals, this fixes it.
