### PR TITLE
Atom group tiling

### DIFF
--- a/integrals/doi.cpp
+++ b/integrals/doi.cpp
@@ -33,12 +33,7 @@ namespace integrals {
         auto fill = nwx_TA::FillNDFunctor<value_type<element_type>, libint2::Operator::delta, 4>();
         fill.initialize(nwx_libint::make_basis_sets({bra, bra, ket, ket}), deriv, thresh, cs_thresh);
 
-        TA::TiledRange trange;
-        if (atom_ranges.empty()) {
-            trange = nwx_TA::make_trange({bra, bra, ket, ket}, tile_size);
-        } else {
-            trange = nwx_TA::make_trange({bra, bra, ket, ket}, atom_ranges);
-        }
+        auto trange = nwx_TA::select_tiling({bra, bra, ket, ket}, tile_size, atom_ranges);
 
         auto I = TiledArray::make_array<tensor<element_type>>(world, trange, fill);
 

--- a/integrals/edipole_integral.cpp
+++ b/integrals/edipole_integral.cpp
@@ -36,12 +36,7 @@ namespace integrals {
 
         auto nopers = libint2::operator_traits<libint2::Operator::emultipole1>::nopers;
         auto component_range = nwx_TA::make_tiled_range(nopers, nopers);
-        TA::TiledRange trange;
-        if (atom_ranges.empty()) {
-            trange = nwx_TA::make_trange({bra, ket}, tile_size, {component_range});
-        } else {
-            trange = nwx_TA::make_trange({bra, ket}, atom_ranges, {component_range});
-        }
+        auto trange = nwx_TA::select_tiling({bra, ket}, tile_size, atom_ranges, {component_range});
 
         auto S = TiledArray::make_array<tensor<element_type>>(world, trange, fill);
 

--- a/integrals/eoctopole_integral.cpp
+++ b/integrals/eoctopole_integral.cpp
@@ -36,12 +36,7 @@ namespace integrals {
 
         auto nopers = libint2::operator_traits<libint2::Operator::emultipole3>::nopers;
         auto component_range = nwx_TA::make_tiled_range(nopers, nopers);
-        TA::TiledRange trange;
-        if (atom_ranges.empty()) {
-            trange = nwx_TA::make_trange({bra, ket}, tile_size, {component_range});
-        } else {
-            trange = nwx_TA::make_trange({bra, ket}, atom_ranges, {component_range});
-        }
+        auto trange = nwx_TA::select_tiling({bra, ket}, tile_size, atom_ranges, {component_range});
 
         auto S = TiledArray::make_array<tensor<element_type>>(world, trange, fill);
 

--- a/integrals/equadrupole_integral.cpp
+++ b/integrals/equadrupole_integral.cpp
@@ -36,12 +36,7 @@ namespace integrals {
 
         auto nopers = libint2::operator_traits<libint2::Operator::emultipole2>::nopers;
         auto component_range = nwx_TA::make_tiled_range(nopers, nopers);
-        TA::TiledRange trange;
-        if (atom_ranges.empty()) {
-            trange = nwx_TA::make_trange({bra, ket}, tile_size, {component_range});
-        } else {
-            trange = nwx_TA::make_trange({bra, ket}, atom_ranges, {component_range});
-        }
+        auto trange = nwx_TA::select_tiling({bra, ket}, tile_size, atom_ranges, {component_range});
 
         auto S = TiledArray::make_array<tensor<element_type>>(world, trange, fill);
 

--- a/integrals/eri2c_integral.cpp
+++ b/integrals/eri2c_integral.cpp
@@ -33,12 +33,7 @@ namespace integrals {
         auto fill = nwx_TA::FillNDFunctor<value_type<element_type>, libint2::Operator::coulomb, 2>();
         fill.initialize(nwx_libint::make_basis_sets({bra, ket}), deriv, thresh, cs_thresh);
 
-        TA::TiledRange trange;
-        if (atom_ranges.empty()) {
-            trange = nwx_TA::make_trange({bra, ket}, tile_size);
-        } else {
-            trange = nwx_TA::make_trange({bra, ket}, atom_ranges);
-        }
+        auto trange = nwx_TA::select_tiling({bra, ket}, tile_size, atom_ranges);
 
         auto I = TiledArray::make_array<tensor<element_type>>(world, trange, fill);
 

--- a/integrals/eri3c_integral.cpp
+++ b/integrals/eri3c_integral.cpp
@@ -45,12 +45,7 @@ namespace integrals {
             fill.screen.cs_mat2 = cs_mat;
         }
 
-        TA::TiledRange trange;
-        if (atom_ranges.empty()) {
-            trange = nwx_TA::make_trange({bra, ket1, ket2}, tile_size);
-        } else {
-            trange = nwx_TA::make_trange({bra, ket1, ket2}, atom_ranges);
-        }
+        auto trange = nwx_TA::select_tiling({bra, ket1, ket2}, tile_size, atom_ranges);
 
         auto I = TiledArray::make_array<tensor<element_type>>(world, trange, fill);
 

--- a/integrals/eri4c_integral.cpp
+++ b/integrals/eri4c_integral.cpp
@@ -47,12 +47,7 @@ namespace integrals {
             fill.screen.cs_mat2 = cs_mat2;
         }
 
-        TA::TiledRange trange;
-        if (atom_ranges.empty()) {
-            trange = nwx_TA::make_trange({bra1, bra2, ket1, ket2}, tile_size);
-        } else {
-            trange = nwx_TA::make_trange({bra1, bra2, ket1, ket2}, atom_ranges);
-        }
+        auto trange = nwx_TA::select_tiling({bra1, bra2, ket1, ket2}, tile_size, atom_ranges);
 
         auto I = TiledArray::make_array<tensor<element_type>>(world, trange, fill);
 

--- a/integrals/kinetic_integral.cpp
+++ b/integrals/kinetic_integral.cpp
@@ -33,12 +33,7 @@ namespace integrals {
         auto fill = nwx_TA::FillNDFunctor<value_type<element_type>, libint2::Operator::kinetic, 2>();
         fill.initialize(nwx_libint::make_basis_sets({bra, ket}), deriv, thresh, cs_thresh);
 
-        TA::TiledRange trange;
-        if (atom_ranges.empty()) {
-            trange = nwx_TA::make_trange({bra, ket}, tile_size);
-        } else {
-            trange = nwx_TA::make_trange({bra, ket}, atom_ranges);
-        }
+        auto trange = nwx_TA::select_tiling({bra, ket}, tile_size, atom_ranges);
 
         auto T = TiledArray::make_array<tensor<element_type>>(world, trange, fill);
 

--- a/integrals/libint_integral.hpp
+++ b/integrals/libint_integral.hpp
@@ -13,6 +13,8 @@ namespace property_types {
     struct LibIntIntegral : public sde::PropertyType<LibIntIntegral<ElementType>> {
         /// Size type vector
         using size_vec = std::vector<type::size>;
+        /// Pair vector
+        using pair_vec = std::vector<std::pair<type::size, type::size>>;
         /// Generates the input fields required by this property type
         auto inputs_();
         /// Generates the result fields required by this property type
@@ -27,7 +29,7 @@ namespace property_types {
                 .add_field<ElementType>("Threshold", 1.0E-16)
                 .template add_field<size_vec>("Tile Size", size_vec{180})
                 .template add_field<ElementType>("Screening Threshold", 0.0)
-                .template add_field<std::vector<size_vec>>("Atom Tile Groups", std::vector<size_vec>{});
+                .template add_field<pair_vec>("Atom Tile Groups", pair_vec{});
         rv["Threshold"].set_description("Convergence threshold of integrals");
         rv["Tile Size"].set_description("Size threshold for tiling tensors by atom blocks");
         rv["Screening Threshold"].set_description("Threshold for Cauchy-Schwarz screening");

--- a/integrals/nuclear_integral.cpp
+++ b/integrals/nuclear_integral.cpp
@@ -38,12 +38,7 @@ namespace integrals {
         fill.initialize(nwx_libint::make_basis_sets({bra, ket}), deriv, thresh, cs_thresh);
         fill.factory.qs = qs;
 
-        TA::TiledRange trange;
-        if (atom_ranges.empty()) {
-            trange = nwx_TA::make_trange({bra, ket}, tile_size);
-        } else {
-            trange = nwx_TA::make_trange({bra, ket}, atom_ranges);
-        }
+        auto trange = nwx_TA::select_tiling({bra, ket}, tile_size, atom_ranges);
 
         auto V = TiledArray::make_array<tensor<element_type>>(world, trange, fill);
 

--- a/integrals/nwx_TA/nwx_TA_utils.cpp
+++ b/integrals/nwx_TA/nwx_TA_utils.cpp
@@ -124,8 +124,8 @@ namespace nwx_TA {
 
     template<typename basis_type>
     TA::TiledRange _make_trange(const std::vector<basis_type>& basis_sets,
-                               const std::vector<size>& tile_sizes,
-                               std::vector<TA::TiledRange1> ranges) {
+                                const std::vector<size>& tile_sizes,
+                                std::vector<TA::TiledRange1> ranges) {
         for (const auto& basis_set : basis_sets) ranges.push_back(make_tiled_range(basis_set, tile_sizes));
         TA::TiledRange trange(ranges.begin(), ranges.end());
         return trange;
@@ -145,7 +145,7 @@ namespace nwx_TA {
 
     template<typename basis_type>
     TA::TiledRange _make_trange(const std::vector<basis_type>& basis_sets,
-                                const std::vector<std::vector<size>>& atom_ranges,
+                                const std::vector<std::pair<size, size>>& atom_ranges,
                                 std::vector<TA::TiledRange1> ranges) {
 
         for (const auto& basis_set : basis_sets) {
@@ -157,7 +157,7 @@ namespace nwx_TA {
                 size next_tile_size = 0;
 
                 // Add the total basis set count for current atom range to the last bound
-                for (auto atom : atom_range) {
+                for (auto atom = atom_range.first; atom < atom_range.second; ++atom) {
                     next_tile_size += basis_set[atom].n_aos();
                 }
                 // Push back bound
@@ -173,15 +173,42 @@ namespace nwx_TA {
     }
 
     TA::TiledRange make_trange(const std::vector<basis<double>>& basis_sets,
-                               const std::vector<std::vector<size>>& atom_ranges,
+                               const std::vector<std::pair<size, size>>& atom_ranges,
                                std::vector<TA::TiledRange1> ranges) {
         return _make_trange(basis_sets, atom_ranges, std::move(ranges));
     }
 
     TA::TiledRange make_trange(const std::vector<basis<float>>& basis_sets,
-                               const std::vector<std::vector<size>>& atom_ranges,
+                               const std::vector<std::pair<size, size>>& atom_ranges,
                                std::vector<TA::TiledRange1> ranges) {
         return _make_trange(basis_sets, atom_ranges, std::move(ranges));
+    }
+
+    template<typename basis_type>
+    TA::TiledRange _select_tiling(const std::vector<basis_type>& basis_sets,
+                                  const std::vector<size>& tile_sizes,
+                                  const std::vector<std::pair<size, size>>& atom_ranges,
+                                  std::vector<TA::TiledRange1> ranges) {
+
+        if (atom_ranges.empty()) {
+            return make_trange(basis_sets, tile_sizes, ranges);
+        } else {
+            return make_trange(basis_sets, atom_ranges, ranges);
+        }
+    }
+
+    TA::TiledRange select_tiling(const std::vector<basis<double>>& basis_sets,
+                                 const std::vector<size>& tile_sizes,
+                                 const std::vector<std::pair<size, size>>& atom_ranges,
+                                 std::vector<TA::TiledRange1> ranges){
+        return _select_tiling(basis_sets, tile_sizes, atom_ranges, std::move(ranges));
+    }
+
+    TA::TiledRange select_tiling(const std::vector<basis<float>>& basis_sets,
+                                 const std::vector<size>& tile_sizes,
+                                 const std::vector<std::pair<size, size>>& atom_ranges,
+                                 std::vector<TA::TiledRange1> ranges){
+        return _select_tiling(basis_sets, tile_sizes, atom_ranges, std::move(ranges));
     }
 
 } // namespace nwx_TA

--- a/integrals/nwx_TA/nwx_TA_utils.hpp
+++ b/integrals/nwx_TA/nwx_TA_utils.hpp
@@ -104,11 +104,31 @@ namespace nwx_TA {
      *  @returns The TiledArray TiledRange made from all of the TiledRange1
      */
     TA::TiledRange make_trange(const std::vector<basis<double>>& basis_sets,
-                               const std::vector<std::vector<size>>& atom_ranges,
+                               const std::vector<std::pair<size, size>>& atom_ranges,
                                std::vector<TA::TiledRange1> ranges = {});
 
     TA::TiledRange make_trange(const std::vector<basis<float>>& basis_sets,
-                               const std::vector<std::vector<size>>& atom_ranges,
+                               const std::vector<std::pair<size, size>>& atom_ranges,
                                std::vector<TA::TiledRange1> ranges = {});
+
+    /** @brief Make trange from basis set and tiling information.
+     *
+     *  Based on tiling settings, return the appropriate TiledRange.
+     *
+     *  @param[in] basis_sets The vector of LibChemist basis sets
+     *  @param[in] tile_sizes The vector of tile sizes
+     *  @param[in] atom_ranges The vector of atoms ranges per tile
+     *  @param[in] ranges A potentially empty vector of premade TiledRange1
+     *  @returns The TiledArray TiledRange made from all of the TiledRange1
+     */
+    TA::TiledRange select_tiling(const std::vector<basis<double>>& basis_sets,
+                                 const std::vector<size>& tile_sizes,
+                                 const std::vector<std::pair<size, size>>& atom_ranges,
+                                 std::vector<TA::TiledRange1> ranges = {});
+
+    TA::TiledRange select_tiling(const std::vector<basis<float>>& basis_sets,
+                                 const std::vector<size>& tile_sizes,
+                                 const std::vector<std::pair<size, size>>& atom_ranges,
+                                 std::vector<TA::TiledRange1> ranges = {});
 
 } // namespace nwx_TA

--- a/integrals/nwx_direct/eri_direct.cpp
+++ b/integrals/nwx_direct/eri_direct.cpp
@@ -51,12 +51,7 @@ namespace integrals {
         }
         auto bfactory = bfactory_type(master);
 
-        TA::TiledRange trange;
-        if (atom_ranges.empty()) {
-            trange = nwx_TA::make_trange({bra, ket1, ket2}, tile_size);
-        } else {
-            trange = nwx_TA::make_trange({bra, ket1, ket2}, atom_ranges);
-        }
+        auto trange = nwx_TA::select_tiling({bra, ket1, ket2}, tile_size, atom_ranges);
         auto I = tensor(world, trange);
 
         auto initer = [=](TA::Range& range) { return direct_type(range, bfactory(range)); };
@@ -104,12 +99,7 @@ namespace integrals {
         }
         auto bfactory = bfactory_type(master);
 
-        TA::TiledRange trange;
-        if (atom_ranges.empty()) {
-            trange = nwx_TA::make_trange({bra1, bra2, ket1, ket2}, tile_size);
-        } else {
-            trange = nwx_TA::make_trange({bra1, bra2, ket1, ket2}, atom_ranges);
-        }
+        auto trange = nwx_TA::select_tiling({bra1, bra2, ket1, ket2}, tile_size, atom_ranges);
         auto I = tensor(world, trange);
 
         auto initer = [=](TA::Range& range) { return direct_type(range, bfactory(range)); };

--- a/integrals/nwx_direct/stg_direct.cpp
+++ b/integrals/nwx_direct/stg_direct.cpp
@@ -52,12 +52,7 @@ namespace integrals {
         }
         auto bfactory = bfactory_type(master);
 
-        TA::TiledRange trange;
-        if (atom_ranges.empty()) {
-            trange = nwx_TA::make_trange({bra, ket1, ket2}, tile_size);
-        } else {
-            trange = nwx_TA::make_trange({bra, ket1, ket2}, atom_ranges);
-        }
+        auto trange = nwx_TA::select_tiling({bra, ket1, ket2}, tile_size, atom_ranges);
         auto I = tensor(world, trange);
 
         auto initer = [=](TA::Range& range) { return direct_type(range, bfactory(range)); };
@@ -106,12 +101,7 @@ namespace integrals {
         }
         auto bfactory = bfactory_type(master);
 
-        TA::TiledRange trange;
-        if (atom_ranges.empty()) {
-            trange = nwx_TA::make_trange({bra1, bra2, ket1, ket2}, tile_size);
-        } else {
-            trange = nwx_TA::make_trange({bra1, bra2, ket1, ket2}, atom_ranges);
-        }
+        auto trange = nwx_TA::select_tiling({bra1, bra2, ket1, ket2}, tile_size, atom_ranges);
         auto I = tensor(world, trange);
 
         auto initer = [=](TA::Range& range) { return direct_type(range, bfactory(range)); };

--- a/integrals/nwx_direct/yukawa_direct.cpp
+++ b/integrals/nwx_direct/yukawa_direct.cpp
@@ -52,12 +52,7 @@ namespace integrals {
         }
         auto bfactory = bfactory_type(master);
 
-        TA::TiledRange trange;
-        if (atom_ranges.empty()) {
-            trange = nwx_TA::make_trange({bra, ket1, ket2}, tile_size);
-        } else {
-            trange = nwx_TA::make_trange({bra, ket1, ket2}, atom_ranges);
-        }
+        auto trange = nwx_TA::select_tiling({bra, ket1, ket2}, tile_size, atom_ranges);
         auto I = tensor(world, trange);
 
         auto initer = [=](TA::Range& range) { return direct_type(range, bfactory(range)); };
@@ -106,12 +101,7 @@ namespace integrals {
         }
         auto bfactory = bfactory_type(master);
 
-        TA::TiledRange trange;
-        if (atom_ranges.empty()) {
-            trange = nwx_TA::make_trange({bra1, bra2, ket1, ket2}, tile_size);
-        } else {
-            trange = nwx_TA::make_trange({bra1, bra2, ket1, ket2}, atom_ranges);
-        }
+        auto trange = nwx_TA::select_tiling({bra1, bra2, ket1, ket2}, tile_size, atom_ranges);
         auto I = tensor(world, trange);
 
         auto initer = [=](TA::Range& range) { return direct_type(range, bfactory(range)); };

--- a/integrals/overlap_integral.cpp
+++ b/integrals/overlap_integral.cpp
@@ -33,12 +33,7 @@ namespace integrals {
         auto fill = nwx_TA::FillNDFunctor<value_type<element_type>, libint2::Operator::overlap, 2>();
         fill.initialize(nwx_libint::make_basis_sets({bra, ket}), deriv, thresh, cs_thresh);
 
-        TA::TiledRange trange;
-        if (atom_ranges.empty()) {
-            trange = nwx_TA::make_trange({bra, ket}, tile_size);
-        } else {
-            trange = nwx_TA::make_trange({bra, ket}, atom_ranges);
-        }
+        auto trange = nwx_TA::select_tiling({bra, ket}, tile_size, atom_ranges);
 
         auto S = TiledArray::make_array<tensor<element_type>>(world, trange, fill);
 

--- a/integrals/stg2c_integral.cpp
+++ b/integrals/stg2c_integral.cpp
@@ -34,12 +34,7 @@ namespace integrals {
         fill.initialize(nwx_libint::make_basis_sets({bra, ket}), deriv, thresh, cs_thresh);
         fill.factory.stg_exponent = stg_exponent;
 
-        TA::TiledRange trange;
-        if (atom_ranges.empty()) {
-            trange = nwx_TA::make_trange({bra, ket}, tile_size);
-        } else {
-            trange = nwx_TA::make_trange({bra, ket}, atom_ranges);
-        }
+        auto trange = nwx_TA::select_tiling({bra, ket}, tile_size, atom_ranges);
 
         auto I = TiledArray::make_array<tensor<element_type>>(world, trange, fill);
 

--- a/integrals/stg3c_integral.cpp
+++ b/integrals/stg3c_integral.cpp
@@ -46,12 +46,7 @@ namespace integrals {
             fill.screen.cs_mat2 = cs_mat;
         }
 
-        TA::TiledRange trange;
-        if (atom_ranges.empty()) {
-            trange = nwx_TA::make_trange({bra, ket1, ket2}, tile_size);
-        } else {
-            trange = nwx_TA::make_trange({bra, ket1, ket2}, atom_ranges);
-        }
+        auto trange = nwx_TA::select_tiling({bra, ket1, ket2}, tile_size, atom_ranges);
 
         auto I = TiledArray::make_array<tensor<element_type>>(world, trange, fill);
 

--- a/integrals/stg4c_integral.cpp
+++ b/integrals/stg4c_integral.cpp
@@ -48,12 +48,7 @@ namespace integrals {
             fill.screen.cs_mat2 = cs_mat2;
         }
 
-        TA::TiledRange trange;
-        if (atom_ranges.empty()) {
-            trange = nwx_TA::make_trange({bra1, bra2, ket1, ket2}, tile_size);
-        } else {
-            trange = nwx_TA::make_trange({bra1, bra2, ket1, ket2}, atom_ranges);
-        }
+        auto trange = nwx_TA::select_tiling({bra1, bra2, ket1, ket2}, tile_size, atom_ranges);
 
         auto I = TiledArray::make_array<tensor<element_type>>(world, trange, fill);
 

--- a/integrals/yukawa2c_integral.cpp
+++ b/integrals/yukawa2c_integral.cpp
@@ -36,12 +36,7 @@ namespace integrals {
         fill.initialize(nwx_libint::make_basis_sets({bra, ket}), deriv, thresh, cs_thresh);
         fill.factory.stg_exponent = stg_exponent;
 
-        TA::TiledRange trange;
-        if (atom_ranges.empty()) {
-            trange = nwx_TA::make_trange({bra, ket}, tile_size);
-        } else {
-            trange = nwx_TA::make_trange({bra, ket}, atom_ranges);
-        }
+        auto trange = nwx_TA::select_tiling({bra, ket}, tile_size, atom_ranges);
 
         auto I = TiledArray::make_array<tensor<element_type>>(world, trange, fill);
 

--- a/integrals/yukawa3c_integral.cpp
+++ b/integrals/yukawa3c_integral.cpp
@@ -46,12 +46,7 @@ namespace integrals {
             fill.screen.cs_mat2 = cs_mat;
         }
 
-        TA::TiledRange trange;
-        if (atom_ranges.empty()) {
-            trange = nwx_TA::make_trange({bra, ket1, ket2}, tile_size);
-        } else {
-            trange = nwx_TA::make_trange({bra, ket1, ket2}, atom_ranges);
-        }
+        auto trange = nwx_TA::select_tiling({bra, ket1, ket2}, tile_size, atom_ranges);
 
         auto I = TiledArray::make_array<tensor<element_type>>(world, trange, fill);
 

--- a/integrals/yukawa4c_integral.cpp
+++ b/integrals/yukawa4c_integral.cpp
@@ -48,12 +48,7 @@ namespace integrals {
             fill.screen.cs_mat2 = cs_mat2;
         }
 
-        TA::TiledRange trange;
-        if (atom_ranges.empty()) {
-            trange = nwx_TA::make_trange({bra1, bra2, ket1, ket2}, tile_size);
-        } else {
-            trange = nwx_TA::make_trange({bra1, bra2, ket1, ket2}, atom_ranges);
-        }
+        auto trange = nwx_TA::select_tiling({bra1, bra2, ket1, ket2}, tile_size, atom_ranges);
 
         auto I = TiledArray::make_array<tensor<element_type>>(world, trange, fill);
 

--- a/tests/test_doi_TA.cpp
+++ b/tests/test_doi_TA.cpp
@@ -12,11 +12,4 @@ TEST_CASE("DOI") {
     auto [X] = mm.at("DOI").run_as<integral_type>(bs, bs, std::size_t{0});
 
     compare_integrals(X, corr);
-
-    mm.copy_module("DOI", "DOI_1");
-    std::vector<std::vector<std::size_t>> atom_groups{{0, 1, 2}};
-    mm.at("DOI_1").change_input("Atom Tile Groups", atom_groups);
-    auto [X_1] = mm.at("DOI_1").run_as<integral_type>(bs, bs, std::size_t{0});
-
-    compare_integrals(X_1, corr);
 }

--- a/tests/test_kinetic_TA.cpp
+++ b/tests/test_kinetic_TA.cpp
@@ -25,11 +25,4 @@ TEST_CASE("Kinetic") {
     auto [T] = mm.at("Kinetic").run_as<integral_type>(bs, bs, std::size_t{0});
 
     compare_integrals(T, corr);
-
-    mm.copy_module("Kinetic", "Kinetic_1");
-    std::vector<std::vector<std::size_t>> atom_groups{{0}, {1, 2}};
-    mm.at("Kinetic_1").change_input("Atom Tile Groups", atom_groups);
-    auto [T_1] = mm.at("Kinetic_1").run_as<integral_type>(bs, bs, std::size_t{0});
-
-    compare_integrals(T_1, corr);
 }

--- a/tests/test_nuclear_TA.cpp
+++ b/tests/test_nuclear_TA.cpp
@@ -24,11 +24,4 @@ TEST_CASE("Nuclear") {
     auto [V] = mm.at("Nuclear").run_as<integral_type>(bs, bs, molecule, std::size_t{0});
 
     compare_integrals(V, corr);
-
-    mm.copy_module("Nuclear", "Nuclear_1");
-    std::vector<std::vector<std::size_t>> atom_groups{{0, 1}, {2}};
-    mm.at("Nuclear_1").change_input("Atom Tile Groups", atom_groups);
-    auto [V_1] = mm.at("Nuclear_1").run_as<integral_type>(bs, bs, molecule, std::size_t{0});
-
-    compare_integrals(V_1, corr);
 }

--- a/tests/test_overlap_TA.cpp
+++ b/tests/test_overlap_TA.cpp
@@ -77,7 +77,7 @@ TEST_CASE("Overlap") {
     compare_integrals(S, corr);
 
     mm.copy_module("Overlap", "Overlap_1");
-    std::vector<std::vector<std::size_t>> atom_groups{{0}, {1}, {2}};
+    std::vector<std::pair<std::size_t, std::size_t>> atom_groups{{0, 1}, {1, 2}, {2, 3}};
     mm.at("Overlap_1").change_input("Tile size", std::vector<std::size_t>{100});
     mm.at("Overlap_1").change_input("Atom Tile Groups", atom_groups);
     auto [S_1] = mm.at("Overlap_1").run_as<integral_type>(bs, bs, std::size_t{0});

--- a/tests/test_utils.cpp
+++ b/tests/test_utils.cpp
@@ -68,10 +68,16 @@ TEST_CASE("Test Utilities") {
     TA::TiledRange corr_trange1(ranges.begin(), ranges.end());
     REQUIRE(trange1 == corr_trange1);
 
-    std::vector<std::vector<std::size_t>> atom_ranges = {{0, 1}, {2}};
+    std::vector<std::pair<std::size_t, std::size_t>> atom_ranges = {{0, 2}, {2, 3}};
     auto trange2 = nwx_TA::make_trange({sto, adz}, atom_ranges);
     TA::TiledRange1 adz_range{0, 32, 41};
     TA::TiledRange corr_trange2{corr_range2, adz_range};
     REQUIRE(trange2 == corr_trange2);
+
+    auto trange3 = nwx_TA::select_tiling({sto, sto}, {1}, {});
+    REQUIRE(trange3 == corr_trange1);
+
+    auto trange4 = nwx_TA::select_tiling({sto, adz}, {4}, atom_ranges);
+    REQUIRE(trange4 == corr_trange2);
 
 }


### PR DESCRIPTION
## Status

- [x] Ready to go

## Brief Description

Adds the option to tile integrals by atom groupings

## Detailed Description

Most of the work is done by a new overload of `make_trange`, which makes custom tile size vectors for each basis set based on the provided atom groupings. The option is then added as a new parameter for the `LibIntIntegral` property type. Using atom groups will overwrite any setting for tile size.
