### PR TITLE
Check for nullptr in Cauchy-Schwarz

### DIFF
--- a/integrals/cauchy_schwarz.cpp
+++ b/integrals/cauchy_schwarz.cpp
@@ -64,7 +64,9 @@ namespace integrals {
 
             // Find the norm and take the square root
             double infinity_norm = 0.0;
-            for (int a = 0; a < nvals; ++a) { infinity_norm = std::max(infinity_norm, std::abs(vals[a])); }
+            if (vals != nullptr) {
+                for (int a = 0; a < nvals; ++a) { infinity_norm = std::max(infinity_norm, std::abs(vals[a])); }
+            }
             mat[i][j] = std::sqrt(infinity_norm);
             if (same_bs && (i!=j)) { mat[j][i] = mat[i][j]; } // cut down on work
         };


### PR DESCRIPTION
## Status

- [x] Ready to go

## Brief Description
The Cauchy-Schwarz module didn't check if the integral buffer was set to nullptr.
## Detailed Description

## TODOs and/or Questions
