### PR TITLE
Fix Multipole Integrals

### DIFF
--- a/src/integrals/libint/emultipole.cpp
+++ b/src/integrals/libint/emultipole.cpp
@@ -31,8 +31,8 @@ MODULE_CTOR(LibintDipole) {
 
     identity_op I;
     dipole_op r;
-    change_input(I.as_string()).change(I);
-    change_input(r.as_string()).change(r);
+    change_input(I.as_string()).change(std::move(I));
+    change_input(r.as_string()).change(std::move(r));
 
     add_input<double>("Threshold").set_default(1.0E-16);
     add_input<size_vector>("Tile Size").set_default(size_vector{180});

--- a/tests/integrals/libint/test_edipole_TA.cpp
+++ b/tests/integrals/libint/test_edipole_TA.cpp
@@ -20,7 +20,7 @@ TEST_CASE("Dipole") {
     const auto bs   = basis_set::sto3g;
     auto aos        = get_bases(name, bs);
     std::vector bases{bs, bs};
-    // auto tensors = get_ao_data(name, bases, property::dipole, world);
+    auto corr = get_ao_data(name, bases, property::dipole, world);
     d_op r;
 
     // SECTION("overlap matrix") {
@@ -30,8 +30,7 @@ TEST_CASE("Dipole") {
     // }
 
     SECTION("dipole matrix") {
-        // auto [D]  = mm.at("EDipole").run_as<d_type>(aos, r, aos);
-        // auto corr = tensors.at(mokup::property::dipole);
-        // REQUIRE(libchemist::tensor::allclose(D, corr));
+        auto [D] = mm.at("EDipole").run_as<d_type>(aos, r, aos);
+        REQUIRE(libchemist::tensor::allclose(D, corr));
     }
 }


### PR DESCRIPTION
The multipole integral ctor contends with the fact that the module computes not only the multipole integral, but also the overlap integral. To do this it sets default values for the operators which will be passed in. The way it used to work actually set the input to a reference; that reference then went out of scope when the ctor finished, eventually leading to a segfault. This PR fixes that by giving ownership to the inputs.

This PR is r2g.