### PR TITLE
Fixes dangling reference

### DIFF
--- a/src/integrals/libint/emultipole.cpp
+++ b/src/integrals/libint/emultipole.cpp
@@ -104,9 +104,9 @@ MODULE_CTOR(LibintQuadrupole) {
     dipole_op r;
     quadrupole_op r2;
 
-    change_input(I.as_string()).change(I);
-    change_input(r.as_string()).change(r);
-    change_input(r2.as_string()).change(r2);
+    change_input(I.as_string()).change(std::move(I));
+    change_input(r.as_string()).change(std::move(r));
+    change_input(r2.as_string()).change(std::move(r2));
 
     add_input<double>("Threshold").set_default(1.0E-16);
     add_input<size_vector>("Tile Size").set_default(size_vector{180});
@@ -182,10 +182,10 @@ MODULE_CTOR(LibintOctupole) {
     quadrupole_op r2;
     octupole_op r3;
 
-    change_input(I.as_string()).change(I);
-    change_input(r.as_string()).change(r);
-    change_input(r2.as_string()).change(r2);
-    change_input(r3.as_string()).change(r3);
+    change_input(I.as_string()).change(std::move(I));
+    change_input(r.as_string()).change(std::move(r));
+    change_input(r2.as_string()).change(std::move(r2));
+    change_input(r3.as_string()).change(std::move(r3));
 
     add_input<double>("Threshold").set_default(1.0E-16);
     add_input<size_vector>("Tile Size").set_default(size_vector{180});


### PR DESCRIPTION
The type-erasure semantics changed slightly with the new `AnyField` causing the multipole operators to hold dangling references. This PR moves the instances into the inputs to avoid this. It's r2g once it passes CI