### PR TITLE
Cache the build process for Integrals

### DIFF
--- a/.github/workflows/c-cpp.yaml
+++ b/.github/workflows/c-cpp.yaml
@@ -6,7 +6,7 @@ on:
       - master
 jobs:
   build-with-gcc:
-    uses: NWChemEx-Project/.github/.github/workflows/c-cpp_tmpl.yaml@cache-build2
+    uses: NWChemEx-Project/.github/.github/workflows/c-cpp_tmpl.yaml@master
     with: 
       dependencies: 'ninja gcc cmake gcovr openblas cblas lapacke scalapack boost eigen3 openmpi libint'
       clang-build: false
@@ -15,7 +15,7 @@ jobs:
     secrets:
       CPP_GITHUB_TOKEN: ${{ secrets.CPP_GITHUB_TOKEN }}
   build-with-clang:
-    uses: NWChemEx-Project/.github/.github/workflows/c-cpp_tmpl.yaml@cache-build2
+    uses: NWChemEx-Project/.github/.github/workflows/c-cpp_tmpl.yaml@master
     with: 
       dependencies: 'ninja clang cmake gcovr openblas cblas lapacke scalapack boost eigen3 openmpi libint'
       clang-build: true


### PR DESCRIPTION
Currently the building time of master branch for Integrals are 1 hour and 34 minutes. With new caching (libint, SimDE and tiled-array), the expected time for building Integrals are 30 minutes.