### PR TITLE
CMake Option Correction

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -57,7 +57,7 @@ cmaize_find_or_build_dependency(
     FIND_TARGET nwx::simde
     CMAKE_ARGS BUILD_TESTING=OFF
                BUILD_PYBIND11_PYBINDINGS=${BUILD_PYBIND11_PYBINDINGS}
-               BUILD_SIGMA=${BUILD_SIGMA}
+               ENABLE_SIGMA=${ENABLE_SIGMA}
 )
 
 cmaize_add_library(


### PR DESCRIPTION
**Description**
The CMake option `ENABLE_SIGMA` was mislabeled as `BUILD_SIGMA` when passed to the SimDE dependency.