### PR TITLE
Add more context to error messages

### DIFF
--- a/src/integrals/ao_integrals/coulomb_metric.cpp
+++ b/src/integrals/ao_integrals/coulomb_metric.cpp
@@ -35,7 +35,7 @@ struct Kernel {
         if constexpr(types::is_uncertain_v<clean_type> ||
                      types::is_interval_v<clean_type>) {
             throw std::runtime_error(
-              "Coulomb Metric does not support UQ types");
+              "integrals::ao_integrals::CoulombMetric: UQ types not supported");
         } else {
             auto rows = m_shape.extent(0);
             auto cols = m_shape.extent(1);

--- a/src/integrals/ao_integrals/uq_atom_symm_blocked_driver.cpp
+++ b/src/integrals/ao_integrals/uq_atom_symm_blocked_driver.cpp
@@ -29,12 +29,12 @@ namespace {
 template<typename UQType, typename T, typename Tensor>
 auto average_error(T&& strides, T&& nbf, T&& ao_i, Tensor&& error,
                    utils::mean_type mean) {
-    using demangler_type = ::utilities::printing::Demangler;
     std::string error_base =
       "integrals::ao_integrals::UQAtomSymmBlockedDriver: ";
 
 #ifdef ENABLE_SIGMA
-    using float_type = typename UQType::value_t;
+    using float_type     = typename UQType::value_t;
+    using demangler_type = ::utilities::printing::Demangler;
 
     auto n_elements = nbf[0] * nbf[1] * nbf[2] * nbf[3];
 

--- a/src/integrals/ao_integrals/uq_atom_symm_blocked_driver.cpp
+++ b/src/integrals/ao_integrals/uq_atom_symm_blocked_driver.cpp
@@ -29,12 +29,12 @@ namespace {
 template<typename UQType, typename T, typename Tensor>
 auto average_error(T&& strides, T&& nbf, T&& ao_i, Tensor&& error,
                    utils::mean_type mean) {
-#ifdef ENABLE_SIGMA
-    using float_type = typename UQType::value_t;
-
     using demangler_type = ::utilities::printing::Demangler;
     std::string error_base =
       "integrals::ao_integrals::UQAtomSymmBlockedDriver: ";
+
+#ifdef ENABLE_SIGMA
+    using float_type = typename UQType::value_t;
 
     auto n_elements = nbf[0] * nbf[1] * nbf[2] * nbf[3];
 

--- a/src/integrals/ao_integrals/uq_atom_symm_blocked_driver.cpp
+++ b/src/integrals/ao_integrals/uq_atom_symm_blocked_driver.cpp
@@ -31,7 +31,12 @@ auto average_error(T&& strides, T&& nbf, T&& ao_i, Tensor&& error,
                    utils::mean_type mean) {
 #ifdef ENABLE_SIGMA
     using float_type = typename UQType::value_t;
-    auto n_elements  = nbf[0] * nbf[1] * nbf[2] * nbf[3];
+
+    using demangler_type = ::utilities::printing::Demangler;
+    std::string error_base =
+      "integrals::ao_integrals::UQAtomSymmBlockedDriver: ";
+
+    auto n_elements = nbf[0] * nbf[1] * nbf[2] * nbf[3];
 
     if(mean == utils::mean_type::none) {
         std::vector<UQType> result;
@@ -50,7 +55,10 @@ auto average_error(T&& strides, T&& nbf, T&& ao_i, Tensor&& error,
                         } else if constexpr(types::is_uncertain_v<UQType>) {
                             result.push_back(UQType{0.0, ei});
                         } else {
-                            throw std::runtime_error("Invalid UQ type");
+                            auto type0 = demangler_type::demangle<UQType>();
+                            throw std::runtime_error(
+                              error_base + "Invalid UQ type " + type0 +
+                              " for non-mean reduction");
                         }
                     }
                 }
@@ -80,10 +88,12 @@ auto average_error(T&& strides, T&& nbf, T&& ao_i, Tensor&& error,
     } else if constexpr(types::is_uncertain_v<UQType>) {
         return std::vector<UQType>(n_elements, UQType{0.0, mean_value});
     } else {
-        throw std::runtime_error("Invalid UQ type");
+        auto type0 = demangler_type::demangle<UQType>();
+        throw std::runtime_error(error_base + "Invalid UQ type " + type0 +
+                                 " for mean reduction");
     }
 #else
-    throw std::runtime_error("Sigma support not enabled!");
+    throw std::runtime_error(error_base + "Sigma support not enabled!");
     return std::vector<UQType>{};
 #endif
 }
@@ -156,7 +166,9 @@ void set_block(T&& strides, T&& nbf,
 
 template<template<typename> typename UQType>
 struct Kernel {
-    using shape_type = buffer::Contiguous::shape_type;
+    using shape_type     = buffer::Contiguous::shape_type;
+    using demangler_type = ::utilities::printing::Demangler;
+
     Kernel(shape_type shape, std::array<simde::type::ao_basis_set, 4> aos,
            utils::mean_type mean) :
       m_shape(std::move(shape)), m_aos(aos), m_mean(mean) {}
@@ -164,8 +176,13 @@ struct Kernel {
     template<typename FloatType0, typename FloatType1>
     Tensor operator()(const std::span<FloatType0> t,
                       const std::span<FloatType1> error) {
+        auto type0 = demangler_type::demangle<FloatType0>();
+        auto type1 = demangler_type::demangle<FloatType1>();
         throw std::runtime_error(
-          "UQ Integrals Driver kernel only supports same float types");
+          m_error_base +
+          "UQ Integrals Driver kernel only supports same "
+          "float types. Got FloatType0 = " +
+          type0 + " and FloatType1 = " + type1);
     }
 
     template<typename FloatType>
@@ -176,7 +193,10 @@ struct Kernel {
         using float_type = std::decay_t<FloatType>;
         if constexpr(types::is_uncertain_v<float_type> ||
                      types::is_interval_v<float_type>) {
-            throw std::runtime_error("Did not expect an uncertain type");
+            auto type0 = demangler_type::demangle<FloatType>();
+            throw std::runtime_error(
+              m_error_base + "Expected non-UQ floating point type, but got " +
+              type0);
         } else {
 #ifdef ENABLE_SIGMA
             using tensorwrapper::buffer::make_contiguous;
@@ -259,7 +279,8 @@ struct Kernel {
                                                          m_shape);
             rv = tensorwrapper::Tensor(m_shape, std::move(t_w_contig));
 #else
-            throw std::runtime_error("Sigma support not enabled!");
+            throw std::runtime_error(m_error_base +
+                                     "Sigma support not enabled!");
 #endif
         }
 
@@ -268,6 +289,8 @@ struct Kernel {
     shape_type m_shape;
     std::array<simde::type::ao_basis_set, 4> m_aos;
     utils::mean_type m_mean;
+    std::string m_error_base =
+      "integrals::ao_integrals::UQAtomSymmBlockedDriver: ";
 };
 
 const auto desc = R"(
@@ -326,7 +349,10 @@ MODULE_RUN(UQAtomSymmBlockedDriver) {
         Kernel<tensorwrapper::types::interval_type> k(shape, aos, mean);
         t_w_error = visit_contiguous_buffer(k, t_buffer, e_buffer);
     } else {
-        throw std::runtime_error("Invalid UQ type");
+        throw std::runtime_error(
+          "integrals::ao_integrals::UQAtomSymmBlockedDriver: Invalid UQ type "
+          "name " +
+          uq_type);
     }
     auto rv = results();
     return eri_pt::wrap_results(rv, t_w_error);

--- a/src/integrals/ao_integrals/uq_driver.cpp
+++ b/src/integrals/ao_integrals/uq_driver.cpp
@@ -28,15 +28,22 @@ namespace {
 
 template<template<typename> typename UQType>
 struct Kernel {
-    using shape_type = buffer::Contiguous::shape_type;
+    using shape_type     = buffer::Contiguous::shape_type;
+    using demangler_type = ::utilities::printing::Demangler;
+
     Kernel(shape_type shape, utils::mean_type mean) :
       m_shape(std::move(shape)), m_mean(mean) {}
 
     template<typename FloatType0, typename FloatType1>
     Tensor operator()(const std::span<FloatType0> t,
                       const std::span<FloatType1> error) {
+        auto type0 = demangler_type::demangle<FloatType0>();
+        auto type1 = demangler_type::demangle<FloatType1>();
         throw std::runtime_error(
-          "UQ Integrals Driver kernel only supports same float types");
+          m_error_base +
+          "Expected same float types for t and error, but got "
+          "FloatType0 = " +
+          type0 + " and FloatType1 = " + type1);
     }
 
     template<typename FloatType>
@@ -47,7 +54,10 @@ struct Kernel {
         using float_type = std::decay_t<FloatType>;
         if constexpr(types::is_uncertain_v<float_type> ||
                      types::is_interval_v<float_type>) {
-            throw std::runtime_error("Did not expect an uncertain type");
+            auto type0 = demangler_type::demangle<FloatType>();
+            throw std::runtime_error(
+              m_error_base + "Expected non-UQ floating point type, but got " +
+              type0);
         } else {
 #ifdef ENABLE_SIGMA
             using uq_type  = UQType<float_type>;
@@ -64,7 +74,10 @@ struct Kernel {
                     } else if constexpr(types::is_uncertain_v<uq_type>) {
                         rv_data[i] = uq_type{elem, error[i]};
                     } else {
-                        throw std::runtime_error("Invalid UQ type");
+                        auto type0 = demangler_type::demangle<uq_type>();
+                        throw std::runtime_error(m_error_base +
+                                                 "Invalid UQ type " + type0 +
+                                                 " for non-mean reduction");
                     }
                 }
             } else {
@@ -75,7 +88,9 @@ struct Kernel {
                 } else if constexpr(types::is_uncertain_v<uq_type>) {
                     max_uq = uq_type(0.0, max_error);
                 } else {
-                    throw std::runtime_error("Invalid UQ type");
+                    auto type0 = demangler_type::demangle<uq_type>();
+                    throw std::runtime_error(m_error_base + "Invalid UQ type " +
+                                             type0 + " for mean reduction");
                 }
                 for(std::size_t i = 0; i < t.size(); ++i) {
                     const auto elem = t[i];
@@ -84,7 +99,8 @@ struct Kernel {
             }
             rv = tensorwrapper::Tensor(m_shape, std::move(rv_buffer));
 #else
-            throw std::runtime_error("Sigma support not enabled!");
+            throw std::runtime_error(m_error_base +
+                                     "Sigma support not enabled!");
 #endif
         }
 
@@ -92,6 +108,7 @@ struct Kernel {
     }
     shape_type m_shape;
     utils::mean_type m_mean;
+    std::string m_error_base = "integrals::ao_integrals::UQDriver: ";
 };
 
 const auto desc = R"(
@@ -139,7 +156,8 @@ MODULE_RUN(UQDriver) {
         Kernel<tensorwrapper::types::interval_type> k(shape, mean);
         t_w_error = visit_contiguous_buffer(k, t_buffer, error_buffer);
     } else {
-        throw std::runtime_error("Invalid UQ type");
+        throw std::runtime_error(
+          "integrals::ao_integrals::UQDriver: Invalid UQ type name " + uq_type);
     }
     auto rv = results();
     return eri_pt::wrap_results(rv, t_w_error);

--- a/src/integrals/libint/libint.cpp
+++ b/src/integrals/libint/libint.cpp
@@ -58,7 +58,8 @@ TEMPLATED_MODULE_RUN(Libint, BraKetType) {
         using interval_type = tensorwrapper::types::interval_type<float_type>;
         t = detail_::fill_tensor<N, interval_type>(basis_sets, op, rv, thresh);
     } else {
-        throw std::runtime_error("Invalid UQ type");
+        throw std::runtime_error(
+          "integrals::libint::Libint: Invalid UQ type name " + uq_type);
     }
     auto result = results();
     return my_pt::wrap_results(result, t);

--- a/src/integrals/utils/uncertainty_reductions.hpp
+++ b/src/integrals/utils/uncertainty_reductions.hpp
@@ -55,7 +55,9 @@ auto compute_mean(mean_type mean, const ContainerType& span) {
     } else if(mean == mean_type::geometric) {
         return geometric_mean(span);
     } else {
-        throw std::runtime_error("Mean type not supported");
+        throw std::runtime_error("integrals::utils::compute_mean: Mean type " +
+                                 std::to_string(static_cast<int>(mean)) +
+                                 " is not computable.");
     }
 }
 
@@ -67,7 +69,8 @@ inline auto mean_from_string(const std::string& mean_str) {
     } else if(mean_str == std::string("none")) {
         return mean_type::none;
     } else {
-        throw std::runtime_error("Mean type not supported: " + mean_str);
+        throw std::runtime_error("integrals::utils::mean_from_string: " +
+                                 mean_str + " is not supported");
     }
 }
 

--- a/tests/cxx/unit/integrals/ao_integrals/test_uq_atom_symm_blocked_driver.cpp
+++ b/tests/cxx/unit/integrals/ao_integrals/test_uq_atom_symm_blocked_driver.cpp
@@ -29,7 +29,10 @@ auto elem(FloatType value, FloatType error) {
     } else if constexpr(tensorwrapper::types::is_interval_v<UQType>) {
         return UQType{value - error, value + error};
     } else {
-        throw std::runtime_error("Invalid UQ type");
+        ::utilities::printing::Demangler demangler;
+        auto type0 = demangler.template demangle<UQType>();
+        throw std::runtime_error(
+          "UQ Atom Symm Blocked Driver Test: Invalid UQ type " + type0);
     }
 }
 


### PR DESCRIPTION
**Is this pull request associated with an issue(s)?**
No

**Description**
Several of the error messages related to UQ type checking are repetitive and provide little context for where the throw occurred or the conditions that caused it to be thrown. These changes alter the error messages in an attempt to better provide such context.